### PR TITLE
Changes for R2023b for nanmean

### DIFF
--- a/kernel/nanmax.m
+++ b/kernel/nanmax.m
@@ -1,0 +1,29 @@
+function [varargout] = nanmax(varargin)
+%NANMAX Maximum value, ignoring NaNs.
+%   M = NANMAX(A) returns the maximum of A with NaNs treated as missing. 
+%   For vectors, M is the largest non-NaN element in A.  For matrices, M is
+%   a row vector containing the maximum non-NaN element from each column.
+%   For N-D arrays, NANMAX operates along the first non-singleton
+%   dimension.
+%
+%   [M,NDX] = NANMAX(A) returns the indices of the maximum values in A.  If
+%   the values along the first non-singleton dimension contain more than
+%   one maximal element, the index of the first one is returned.
+%  
+%   M = NANMAX(A,B) returns an array the same size as A and B with the
+%   largest elements taken from A or B.  Either one can be a scalar.
+%
+%   M = NANMAX(A,[],'all') returns the largest element of X.
+%
+%   [M,NDX] = NANMAX(A,[],DIM) operates along the dimension DIM.
+%
+%   M = NANMAX(A,[],VECDIM) returns the largest elements of X based 
+%   on the dimensions specified in the vector VECDIM.
+%
+%   See also MAX, NANMIN, NANMEAN, NANMEDIAN, NANMIN, NANVAR, NANSTD.
+
+%   Copyright 1993-2018 The MathWorks, Inc. 
+
+
+% Call [m,ndx] = max(a,b) with as many inputs and outputs as needed
+[varargout{1:nargout}] = max(varargin{:});

--- a/kernel/nanmean.m
+++ b/kernel/nanmean.m
@@ -1,0 +1,22 @@
+function y = nanmean(varargin)
+%NANMEAN Mean value, ignoring NaNs.
+%   M = NANMEAN(X) returns the sample mean of X, treating NaNs as missing
+%   values.  For vector input, M is the mean value of the non-NaN elements
+%   in X.  For matrix input, M is a row vector containing the mean value of
+%   non-NaN elements in each column.  For N-D arrays, NANMEAN operates
+%   along the first non-singleton dimension.
+%
+%   NANMEAN(X,'all') is the mean value of all the elements in X.
+%
+%   NANMEAN(X,DIM) takes the mean along the dimension DIM of X.
+%
+%   NANMEAN(X,VECDIM) finds the mean of the elements of X based on the
+%   dimensions specified in the vector VECDIM.
+%
+%   See also MEAN, NANMEDIAN, NANSTD, NANVAR, NANMIN, NANMAX, NANSUM.
+
+%   Copyright 1993-2018 The MathWorks, Inc.
+
+
+narginchk(1,2);
+y = mean(varargin{:},'omitnan');

--- a/kernel/nanmedian.m
+++ b/kernel/nanmedian.m
@@ -1,0 +1,25 @@
+function y = nanmedian(x,dim)
+%NANMEDIAN Median value, ignoring NaNs.
+%   M = NANMEDIAN(X) returns the sample median of X, treating NaNs as
+%   missing values.  For vector input, M is the median value of the non-NaN
+%   elements in X.  For matrix input, M is a row vector containing the
+%   median value of non-NaN elements in each column.  For N-D arrays,
+%   NANMEDIAN operates along the first non-singleton dimension.
+%
+%   NANMEDIAN(X,'all') is the median value of all the elements of X.
+%
+%   NANMEDIAN(X,DIM) takes the median along the dimension DIM of X.
+%
+%   NANMEDIAN(X,VECDIM) finds the median values of the elements of X based 
+%   on the dimensions specified in the vector VECDIM.
+%
+%   See also MEDIAN, NANMEAN, NANSTD, NANVAR, NANMIN, NANMAX, NANSUM.
+
+%   Copyright 1993-2018 The MathWorks, Inc.
+
+
+if nargin == 1
+    y = prctile(x, 50);
+else
+    y = prctile(x, 50,dim);
+end

--- a/kernel/nanmin.m
+++ b/kernel/nanmin.m
@@ -1,0 +1,29 @@
+function [varargout] = nanmin(varargin)
+%NANMIN Minimum value, ignoring NaNs.
+%   M = NANMIN(A) returns the minimum of A with NaNs treated as missing. 
+%   For vectors, M is the smallest non-NaN element in A.  For matrices, M
+%   is a row vector containing the minimum non-NaN element from each
+%   column.  For N-D arrays, NANMIN operates along the first non-singleton
+%   dimension.
+%
+%   [M,NDX] = NANMIN(A) returns the indices of the minimum values in A.  If
+%   the values along the first non-singleton dimension contain more than
+%   one minimal element, the index of the first one is returned.
+%  
+%   M = NANMIN(A,B) returns an array the same size as A and B with the
+%   smallest elements taken from A or B.  Either one can be a scalar.
+%
+%   M = NANMIN(A,[],'all') returns the smallest element of X.
+%
+%   [M,NDX] = NANMIN(A,[],DIM) operates along the dimension DIM.
+%
+%   M = NANMIN(A,[],VECDIM) returns the smallest elements of X based 
+%   on the dimensions specified in the vector VECDIM.
+%
+%   See also MIN, NANMAX, NANMEAN, NANMEDIAN, NANVAR, NANSTD.
+
+%   Copyright 1993-2018 The MathWorks, Inc. 
+
+
+% Call [m,ndx] = min(a,b) with as many inputs and outputs as needed
+[varargout{1:nargout}] = min(varargin{:});


### PR DESCRIPTION
nanmean / nanmax / nanmin / nanmedian has been deprecated in R2023b.

Adding these functions to kernel so as to allow smooth running.

Tested okay on:
[R2023b](https://gist.github.com/shitong01/f4d96821883f4ec1aaa745e8c13c4cb4#file-r2023b)
[R2019b](https://gist.github.com/shitong01/f4d96821883f4ec1aaa745e8c13c4cb4#file-r2019b)